### PR TITLE
Add longitudinal project support

### DIFF
--- a/includes/REDCap_method.php
+++ b/includes/REDCap_method.php
@@ -2,9 +2,27 @@
 
 $method_data = REDCap::getData($_GET['pid'], 'json', $_GET['record'], NULL, NULL, NULL, FALSE, FALSE, FALSE, FALSE, TRUE);
 
-//$method_data =REDCap::getData('137', 'json', '2');
-
 $json_decoded = json_decode($method_data, TRUE);
 $data = $json_decoded[0];
+
+// when an event id is set, merge the fields of the event data with the main data from above
+if(isset($_GET['event'])){
+        // get data for event
+        $method_data_event = REDCap::getData($_GET['pid'], 'json', $_GET['record'], NULL, $_GET['event'], NULL, FALSE, FALSE, FALSE, FALSE, TRUE);
+
+        $json_decoded_event = json_decode($method_data_event, TRUE);
+        $data_event = $json_decoded_event[0];
+
+        // merge each field onto the main data, preserve main data field if present
+        foreach($data_event AS $var=>$value){
+                if(empty($data[$var])){
+                        $data[$var] = $data_event[$var];
+                }
+        }
+}
+
+// uncomment those lines to view debug fields
+// echo(json_encode($data));
+// exit;
 
 ?>


### PR DESCRIPTION
This PR adds longitudinal project support.
It attempts to merge the main object containing all the data with an event object, if given.
It preserves set fields in the main object.